### PR TITLE
chore: use absolute import within src instead of relative paths

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '^.+\\.(jpg|jpeg|png|gif|webp|avif|svg)$': `<rootDir>/tests/mocks/fileMock.ts`,
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleDirectories: ['node_modules', './src/'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
   transform: {
     // Use babel-jest to transpile tests with the next/babel preset

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,8 +3,8 @@ import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 
 // eslint-disable-next-line import/no-unassigned-import
-import '../lib/i18n';
-import { useApollo } from '../lib/apollo';
+import 'lib/i18n';
+import { useApollo } from 'lib/apollo';
 
 // eslint-disable-next-line import/no-unassigned-import
 import 'normalize.css/normalize.css';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import type { NextPage } from 'next';
 import { useTranslation } from 'react-i18next';
 
-import { i18n, Language } from '../lib/i18n';
+import { i18n, Language } from 'lib/i18n';
 
 const handleClick: React.MouseEventHandler = () => {
   const currentLanguage = i18n.language;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "./src"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Absolute import with:

- typescript with ` baseUr`
- jest with `moduleDirectories`
- replace existing relative import
-